### PR TITLE
Add Type Hints and mypy typechecking

### DIFF
--- a/revex/__init__.py
+++ b/revex/__init__.py
@@ -9,5 +9,6 @@ from .dfa import DFA, AlphabetType  # noqa
 compile = RegularExpression.compile
 
 
-def build_dfa(regex, alphabet=DEFAULT_ALPHABET):  # type: (AnyStr, AlphabetType) -> DFA
+def build_dfa(regex, alphabet=DEFAULT_ALPHABET):
+    # type: (AnyStr, AlphabetType) -> DFA[RegularExpression, AnyStr]
     return compile(regex).as_dfa(alphabet=alphabet)

--- a/revex/__init__.py
+++ b/revex/__init__.py
@@ -1,8 +1,9 @@
-from typing import AnyStr
+from typing import AnyStr  # noqa
 
 
 from .derivative import RegularExpression
-from .dfa import DEFAULT_ALPHABET, DFA, AlphabetType
+from .dfa import DEFAULT_ALPHABET
+from .dfa import DFA, AlphabetType  # noqa
 
 
 compile = RegularExpression.compile

--- a/revex/__init__.py
+++ b/revex/__init__.py
@@ -1,9 +1,12 @@
+from typing import AnyStr
+
+
 from .derivative import RegularExpression
-from .dfa import DEFAULT_ALPHABET
+from .dfa import DEFAULT_ALPHABET, DFA, AlphabetType
 
 
 compile = RegularExpression.compile
 
 
-def build_dfa(regex, alphabet=DEFAULT_ALPHABET):
+def build_dfa(regex, alphabet=DEFAULT_ALPHABET):  # type: (AnyStr, AlphabetType) -> DFA
     return compile(regex).as_dfa(alphabet=alphabet)

--- a/revex/__init__.py
+++ b/revex/__init__.py
@@ -1,14 +1,15 @@
 from typing import Sequence  # noqa
 
-
-from .derivative import RegularExpression
+from .derivative import RegularExpression  # noqa
+from .derivative import RegexVisitor
 from .dfa import DEFAULT_ALPHABET
 from .dfa import DFA, String  # noqa
 
 
-compile = RegularExpression.compile
+def compile(regex):  # type: (String) -> RegularExpression
+    return RegexVisitor().parse(regex)
 
 
 def build_dfa(regex, alphabet=DEFAULT_ALPHABET):
-    # type: (String, Sequence[String]) -> DFA[RegularExpression[String], String]
+    # type: (String, Sequence[String]) -> DFA[RegularExpression]
     return compile(regex).as_dfa(alphabet=alphabet)

--- a/revex/__init__.py
+++ b/revex/__init__.py
@@ -1,14 +1,14 @@
-from typing import AnyStr  # noqa
+from typing import Sequence  # noqa
 
 
 from .derivative import RegularExpression
 from .dfa import DEFAULT_ALPHABET
-from .dfa import DFA, AlphabetType  # noqa
+from .dfa import DFA, String  # noqa
 
 
 compile = RegularExpression.compile
 
 
 def build_dfa(regex, alphabet=DEFAULT_ALPHABET):
-    # type: (AnyStr, AlphabetType) -> DFA[RegularExpression, AnyStr]
+    # type: (String, Sequence[String]) -> DFA[RegularExpression[String], String]
     return compile(regex).as_dfa(alphabet=alphabet)

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -116,7 +116,7 @@ class _Empty(RegularExpression):
 
     accepting = False
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         return EMPTY
 
     def __str__(self):
@@ -139,7 +139,7 @@ class _Epsilon(RegularExpression):
 
     accepting = True
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         return EMPTY
 
     def __str__(self):
@@ -165,7 +165,7 @@ class _Dot(RegularExpression):
 
     accepting = False
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         return EPSILON
 
     def __str__(self):
@@ -320,7 +320,7 @@ class Intersection(RegularExpression):
     def accepting(self):
         return all(child.accepting for child in self.children)
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         return reduce(operator.and_, (child.derivative(char) for child in self.children))
 
     def __str__(self):
@@ -344,7 +344,7 @@ class CharSet(RegularExpression):
     accepting = False
     is_atomic = True
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         if self.negated:
             return EMPTY if char in self.chars else EPSILON
         else:
@@ -428,7 +428,7 @@ class Union(RegularExpression):
     def accepting(self):
         return any(child.accepting for child in self.children)
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         return reduce(operator.or_, (child.derivative(char) for child in self.children))
 
     @property
@@ -470,7 +470,7 @@ class Complement(RegularExpression):
     def accepting(self):
         return not self.regex.accepting
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         return ~self.regex.derivative(char)
 
     @property
@@ -497,7 +497,7 @@ class Star(RegularExpression):
 
     accepting = True
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         return self.regex.derivative(char) + self
 
     @property

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -312,9 +312,8 @@ class Intersection(RegularExpression):
             # accept. These are exactly the chars recognized by this regex, so
             # just return the charset.
             acceptable_chars = {
-                char for char in charset.chars  # type: ignore
-                if all(
-                    child.derivative(char).accepting for child in children)  # type: ignore
+                char for char in charset.chars
+                if all(child.derivative(char).accepting for child in children)
             }  # type: Set[String]
             if not acceptable_chars:
                 return EMPTY

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -13,14 +13,14 @@ import operator
 import re
 import string
 from functools import reduce, total_ordering
-from typing import AnyStr
-from typing import Set
-from typing import Tuple
+from typing import AnyStr  # noqa
+from typing import Set  # noqa
+from typing import Tuple  # noqa
 
 import six
 from parsimonious import NodeVisitor, Grammar
 
-from revex.dfa import AlphabetType, Character, DFA
+from revex.dfa import AlphabetType, Character, DFA  # noqa
 from .dfa import RegexDFA, DEFAULT_ALPHABET
 
 
@@ -333,7 +333,8 @@ class Intersection(RegularExpression):
 @six.python_2_unicode_compatible
 class CharSet(RegularExpression):
     negated = None  # type: bool
-    chars = None  # type: tuple[Character]
+    chars = None  # type: Tuple[Character, ...]
+
     def __new__(cls, chars, negated=False):
         instance = super(CharSet, cls).__new__(cls)
         instance.chars = tuple(sorted(chars))

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -14,6 +14,7 @@ import re
 import string
 from functools import reduce, total_ordering
 from typing import AnyStr  # noqa
+from typing import Optional  # noqa
 from typing import Set  # noqa
 from typing import Tuple  # noqa
 
@@ -269,12 +270,13 @@ class Intersection(RegularExpression):
         children  = (children - charsets) - negated_charsets
         if charsets:
             charset = CharSet(reduce(operator.and_, (set(c.chars) for c in charsets)))
+            # type: Optional[CharSet]
         else:
             charset = None
         if negated_charsets:
             negated_charset = CharSet(
                 reduce(operator.or_, (set(c.chars) for c in negated_charsets)),
-                negated=True)
+                negated=True)  # type: Optional[CharSet]
         else:
             negated_charset = None
 

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -70,13 +70,13 @@ class RegularExpression(object):
         """
         raise NotImplementedError
 
-    def derivative(self, char):
+    def derivative(self, char):  # type: (Character) -> RegularExpression
         raise NotImplementedError
 
     def match(self, string):  # type: (AnyStr) -> bool
         regex = self
-        for char in string:
-            regex = regex.derivative(char)
+        for i in range(len(string)):
+            regex = regex.derivative(string[i:i+1])
         return regex.accepting
 
     @property

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -199,7 +199,7 @@ class Concatenation(RegularExpression):
         elif len(children) == 1:
             return children[0]
         else:
-            instance = super(Concatenation, cls).__new__(cls)  # type: Concatenation
+            instance = super(Concatenation, cls).__new__(cls)
             instance.children = children
             return instance
 

--- a/revex/dfa.py
+++ b/revex/dfa.py
@@ -399,7 +399,7 @@ def minimize_dfa(dfa):
     return new_dfa
 
 
-def construct_integer_dfa(dfa):
+class IntegerDFA(DFA):
     """
     Constructs a DFA whose states are all integers from 0 to (number of states),
     with 0 the start state.
@@ -407,23 +407,23 @@ def construct_integer_dfa(dfa):
     This is more efficient for some algorithms, since arrays/lists can be used
     instead of hash tables.
     """
-    nodes = [dfa.start] + [node for node in dfa.node if node != dfa.start]
-    node_to_index = {node: index for index, node in enumerate(nodes)}
-    int_dfa = DFA(
-        start=node_to_index[dfa.start],
-        start_accepting=dfa.node[dfa.start]['accepting'],
-        alphabet=dfa.alphabet,
-    )
-    for node, attr in six.iteritems(dfa.node):
-        int_dfa.add_state(
-            node_to_index[node],
-            accepting=attr['accepting'],
+    def __init__(self, dfa):  # type: (DFA) -> None
+        nodes = [dfa.start] + [node for node in dfa.node if node != dfa.start]
+        node_to_index = {node: index for index, node in enumerate(nodes)}
+        super(IntegerDFA, self).__init__(
+            start=node_to_index[dfa.start],
+            start_accepting=dfa.node[dfa.start]['accepting'],
+            alphabet=dfa.alphabet,
         )
-    for from_node, trans in six.iteritems(dfa.delta):
-        for char, to_node in six.iteritems(trans):
-            int_dfa.add_transition(
-                node_to_index[from_node],
-                node_to_index[to_node],
-                char,
+        for node, attr in six.iteritems(dfa.node):
+            self.add_state(
+                node_to_index[node],
+                accepting=attr['accepting'],
             )
-    return int_dfa
+        for from_node, trans in six.iteritems(dfa.delta):
+            for char, to_node in six.iteritems(trans):
+                self.add_transition(
+                    node_to_index[from_node],
+                    node_to_index[to_node],
+                    char,
+                )

--- a/revex/dfa.py
+++ b/revex/dfa.py
@@ -9,9 +9,10 @@ import six
 import networkx as nx
 import typing  # noqa
 from six.moves import range
-from typing import Dict  # noqa
-from typing import Sequence  # noqa
 from typing import AnyStr  # noqa
+from typing import Dict  # noqa
+from typing import Optional  # noqa
+from typing import Sequence  # noqa
 
 
 logger = logging.getLogger(__name__)
@@ -254,7 +255,8 @@ class DFA(nx.MultiDiGraph):
                 invalid_nodes.append(from_node)
         return invalid_nodes
 
-    def construct_isomorphism(self, other):  # type: (DFA) -> Dict[typing.Any, typing.Any]
+    def construct_isomorphism(self, other):
+        # type: (DFA) -> Optional[Dict[typing.Any, typing.Any]]
         """
         Returns a mapping of states between self and other exhibiting an
         isomorphism, or None if no isomorphism exists.

--- a/revex/dfa.py
+++ b/revex/dfa.py
@@ -7,11 +7,11 @@ from collections import defaultdict
 
 import six
 import networkx as nx
-import typing
+import typing  # noqa
 from six.moves import range
-from typing import Dict
-from typing import Sequence
-from typing import AnyStr
+from typing import Dict  # noqa
+from typing import Sequence  # noqa
+from typing import AnyStr  # noqa
 
 
 logger = logging.getLogger(__name__)
@@ -199,7 +199,8 @@ class DFA(nx.MultiDiGraph):
             color='green' if accepting else 'black',
         )
 
-    def add_transition(self, from_state, to_state, char):  # type: (NodeType, NodeType, Character) -> None
+    def add_transition(self, from_state, to_state, char):
+        # type: (NodeType, NodeType, Character) -> None
         if not (self.has_node(from_state) and self.has_node(to_state)):
             raise ValueError('States must be added prior to transitions.')
         if self.delta[from_state].get(char) == to_state:
@@ -293,7 +294,7 @@ class RegexDFA(DFA):
         matches that regular expression. In particular, the "start" node is
         labeled with `regex`.
         """
-        from revex.derivative import RegularExpression
+        from revex.derivative import RegularExpression  # noqa
         super(RegexDFA, self).__init__(
             start=regex,
             start_accepting=regex.accepting,

--- a/revex/dfa.py
+++ b/revex/dfa.py
@@ -344,6 +344,7 @@ def get_equivalent_states(dfa):
 
 T = typing.TypeVar('T')
 
+
 def minimize_dfa(dfa):  # type: (DFA[T]) -> DFA[frozenset[T]]
     """
     Constructs a minimized DFA by combining equivalent states.

--- a/revex/dfa.py
+++ b/revex/dfa.py
@@ -3,10 +3,15 @@ from __future__ import unicode_literals
 
 import logging
 import re
+import sys
 from collections import defaultdict
 
 import six
 import networkx as nx
+import typing
+from typing import Dict
+from typing import Sequence
+from typing import Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -27,15 +32,24 @@ class InfiniteLanguageError(RevexError):
     pass
 
 
+NodeType = typing.TypeVar('NodeType')
+
+if sys.version_info < (3, ):
+    Character = typing.Union[str, unicode]
+else:
+    Character = typing.Union[str]
+
+
 class DFA(nx.MultiDiGraph):
     def __init__(self, start, start_accepting, alphabet=DEFAULT_ALPHABET):
+        # type: (NodeType, bool, Sequence[Character]) -> None
         super(DFA, self).__init__()
         self.start = start
         self.add_state(start, start_accepting)
 
-        # Index of (state, char): next char transitions. In the literature, this
+        # Index of (state, char): next state transitions. In the literature, this
         # is usually denoted 𝛿.
-        self.delta = defaultdict(dict)
+        self.delta = defaultdict(dict)  # type: defaultdict[NodeType, Dict[Character, NodeType]]
 
         self.alphabet = alphabet
 

--- a/revex/generation.py
+++ b/revex/generation.py
@@ -10,7 +10,7 @@ from six.moves import range
 from typing import Tuple, Dict, List, Union  # noqa
 
 from revex.dfa import DFA  # noqa
-from revex.dfa import IntegerDFA
+from revex.dfa import construct_integer_dfa
 from revex.dfa import EmptyLanguageError
 from revex.dfa import InfiniteLanguageError
 
@@ -108,7 +108,7 @@ class BaseGenerator(object):
     def __init__(self, dfa):  # type: (DFA) -> None
         if dfa.find_invalid_nodes():  # pragma: no cover
             raise ValueError('Must use a valid DFA.')
-        self.dfa = IntegerDFA(dfa)
+        self.dfa = construct_integer_dfa(dfa)
         self.alphabet = list(self.dfa.alphabet)
 
         self.nodes = range(0, len(self.dfa.node))

--- a/revex/generation.py
+++ b/revex/generation.py
@@ -7,9 +7,9 @@ from bisect import bisect_left
 from itertools import count
 
 from six.moves import range
-from typing import Tuple, Dict, List, Union
+from typing import Tuple, Dict, List, Union  # noqa
 
-from revex.dfa import DFA
+from revex.dfa import DFA  # noqa
 from revex.dfa import IntegerDFA
 from revex.dfa import EmptyLanguageError
 from revex.dfa import InfiniteLanguageError
@@ -21,6 +21,7 @@ class InvalidDistributionError(Exception):
 
 class _Distribution(list):
     pass
+
 
 class DiscreteRandomVariable(_Distribution):
     def __init__(self, counts):  # type: (List[float]) -> None

--- a/revex/generation.py
+++ b/revex/generation.py
@@ -7,13 +7,12 @@ from bisect import bisect_left
 from itertools import count
 
 from six.moves import range
-from typing import Tuple, Dict
+from typing import Tuple, Dict, List, Union
 
 from revex.dfa import DFA
 from revex.dfa import IntegerDFA
 from revex.dfa import EmptyLanguageError
 from revex.dfa import InfiniteLanguageError
-from revex.dfa import NodeType
 
 
 class InvalidDistributionError(Exception):
@@ -24,7 +23,7 @@ class _Distribution(list):
     pass
 
 class DiscreteRandomVariable(_Distribution):
-    def __init__(self, counts):
+    def __init__(self, counts):  # type: (List[float]) -> None
         total = sum(counts, 0.0)
         if total == 0:
             raise InvalidDistributionError()
@@ -49,7 +48,7 @@ class LeastFrequentRoundRobin(_Distribution):
     Draws in a cycle from least frequent to most frequent, ignoring indices
     with zero weighting.
     """
-    def __init__(self, counts):
+    def __init__(self, counts):  # type: (List[Union[float, int]]) -> None
         super(LeastFrequentRoundRobin, self).__init__(
             i for i, count in enumerate(counts) if counts[i] > 0)
         self.sort(key=counts.__getitem__)  # Sort indices from least to most frequent.
@@ -106,8 +105,7 @@ class PathCounts(list):
 
 class BaseGenerator(object):
     def __init__(self, dfa):  # type: (DFA) -> None
-        invalid_nodes = dfa.find_invalid_nodes()
-        if invalid_nodes:  # pragma: no cover
+        if dfa.find_invalid_nodes():  # pragma: no cover
             raise ValueError('Must use a valid DFA.')
         self.dfa = IntegerDFA(dfa)
         self.alphabet = list(self.dfa.alphabet)

--- a/revex/tests/test_dfa.py
+++ b/revex/tests/test_dfa.py
@@ -35,7 +35,7 @@ def test_dfa_matches_builtin(s):
 def test_equivalent_state_computation():
     # Construct a DFA where all states are equivalent to each other.
     alphabet = '01'
-    dfa = DFA(0, True, alphabet=alphabet)  # type: DFA[int, six.text_type]
+    dfa = DFA(0, True, alphabet=alphabet)  # type: DFA[int]
     dfa.add_state(1, True)
     dfa.add_state(2, True)
     dfa.add_state(3, True)
@@ -60,7 +60,7 @@ def test_equivalent_state_example():
     # https://www.tutorialspoint.com/automata_theory/dfa_minimization.htm
     alphabet = '01'
     a, b, c, d, e, f = states = 'abcdef'
-    dfa = DFA(a, False, alphabet=alphabet)  # type: DFA[six.text_type, six.text_type]
+    dfa = DFA(a, False, alphabet=alphabet)  # type: DFA[six.text_type]
     dfa.add_state(b, False)
     dfa.add_state(c, True)
     dfa.add_state(d, True)
@@ -102,7 +102,7 @@ def test_equivalent_state_example():
     new_dfa = minimize_dfa(dfa)
     assert not new_dfa.find_invalid_nodes()
 
-    expected_dfa = DFA('ab', False, alphabet=alphabet)  # type: DFA[six.text_type, six.text_type]
+    expected_dfa = DFA('ab', False, alphabet=alphabet)  # type: DFA[six.text_type]
     expected_dfa.add_state('cde', True)
     expected_dfa.add_state('f', False)
 

--- a/revex/tests/test_dfa.py
+++ b/revex/tests/test_dfa.py
@@ -97,7 +97,7 @@ def test_equivalent_state_example():
     expected |= {(x, x) for x in states}
     expected |= {(p, q) for (q, p) in expected}
 
-    equivalent = get_equivalent_states(dfa)  # type: ignore
+    equivalent = get_equivalent_states(dfa)
     assert equivalent == expected
     new_dfa = minimize_dfa(dfa)
     assert not new_dfa.find_invalid_nodes()

--- a/revex/tests/test_dfa.py
+++ b/revex/tests/test_dfa.py
@@ -1,8 +1,11 @@
 from __future__ import unicode_literals
 
 import re
+from typing import Set  # noqa
+from typing import Tuple  # noqa
 
 import pytest
+import six  # noqa
 from hypothesis import given, example
 from hypothesis import strategies as st
 
@@ -32,7 +35,7 @@ def test_dfa_matches_builtin(s):
 def test_equivalent_state_computation():
     # Construct a DFA where all states are equivalent to each other.
     alphabet = '01'
-    dfa = DFA(0, True, alphabet=alphabet)
+    dfa = DFA(0, True, alphabet=alphabet)  # type: DFA[int, six.text_type]
     dfa.add_state(1, True)
     dfa.add_state(2, True)
     dfa.add_state(3, True)
@@ -44,7 +47,7 @@ def test_equivalent_state_computation():
     dfa.add_transition(2, 2, '1')
     dfa.add_transition(3, 0, '0')
     dfa.add_transition(3, 3, '1')
-    equivalent = get_equivalent_states(dfa)
+    equivalent = get_equivalent_states(dfa)  # type: Set[Tuple[int, int]]
     states = [0, 1, 2, 3]
     assert equivalent == {(p, q) for p in states for q in states}
 
@@ -57,7 +60,7 @@ def test_equivalent_state_example():
     # https://www.tutorialspoint.com/automata_theory/dfa_minimization.htm
     alphabet = '01'
     a, b, c, d, e, f = states = 'abcdef'
-    dfa = DFA(a, False, alphabet=alphabet)
+    dfa = DFA(a, False, alphabet=alphabet)  # type: DFA[six.text_type, six.text_type]
     dfa.add_state(b, False)
     dfa.add_state(c, True)
     dfa.add_state(d, True)
@@ -94,12 +97,12 @@ def test_equivalent_state_example():
     expected |= {(x, x) for x in states}
     expected |= {(p, q) for (q, p) in expected}
 
-    equivalent = get_equivalent_states(dfa)
+    equivalent = get_equivalent_states(dfa)  # type: ignore
     assert equivalent == expected
     new_dfa = minimize_dfa(dfa)
     assert not new_dfa.find_invalid_nodes()
 
-    expected_dfa = DFA('ab', False, alphabet=alphabet)
+    expected_dfa = DFA('ab', False, alphabet=alphabet)  # type: DFA[six.text_type, six.text_type]
     expected_dfa.add_state('cde', True)
     expected_dfa.add_state('f', False)
 

--- a/revex/tests/test_generation.py
+++ b/revex/tests/test_generation.py
@@ -153,7 +153,7 @@ def test_deterministic_generation():
 def test_random_walk_matches_regex(regex):
     actual = re.compile('^%s$' % regex)
     revex_regex = revex.compile(regex)
-    gen = rgen(revex_regex, alphabet=set(regex))
+    gen = rgen(revex_regex, alphabet=list(set(regex)))
     for length in islice(gen.valid_lengths_iter(), 10):
         for _ in range(10):
             rand_string = gen.generate_string(length)

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -2,13 +2,14 @@ import re
 
 import pytest
 
-from revex.derivative import RegularExpression, REGEX
+from revex import compile
+from revex.derivative import REGEX
 
 
 class RE(object):
     def __init__(self, pattern):
         self.base_re = re.compile(r'^(%s)$' % pattern)
-        self.re = RegularExpression.compile(pattern)
+        self.re = compile(pattern)
 
     def match(self, string):
         assert bool(self.base_re.match(string)) == self.re.match(string)
@@ -137,10 +138,10 @@ def test_repeat():
     assert regex.match('a' * 2 + 'q')
     assert not regex.match('a' * 3 + 'q')
 
-    assert RegularExpression.compile('a{3}') == RegularExpression.compile('aaa')
+    assert compile('a{3}') == compile('aaa')
 
-    assert RegularExpression.compile('ba{3}') == RegularExpression.compile('baaa')
-    assert RegularExpression.compile('(ba){3}') == RegularExpression.compile('bababa')
+    assert compile('ba{3}') == compile('baaa')
+    assert compile('(ba){3}') == compile('bababa')
 
 
 def test_character_class_space():

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py27,py35,lint
+envlist = py27,py35,lint,mypy
 
 [tox:travis]
 2.7 = py27
-3.5 = py35, lint
+3.5 = py35, lint, mypy
 
 [testenv]
 install_command = pip install --index-url https://pypi.python.org/simple {opts} {packages}
@@ -15,6 +15,7 @@ basepython =
     py27: python2.7
     py35: python3.5
     lint: python3.5
+    mypy: python3.5
 deps =
     networkx
     parsimonious>=0.7.0
@@ -23,6 +24,7 @@ deps =
     coverage
     pytest
     pytest-cov
+    typing
     ipython
     pdbpp
     hypothesis
@@ -36,6 +38,25 @@ deps =
     flake8-print
 commands =
     flake8 revex
+
+[testenv:mypy]
+deps =
+  mypy-lang==0.4.6
+  networkx
+  parsimonious>=0.7.0
+  six
+  pygraphviz
+  coverage
+  pytest
+  pytest-cov
+  ipython
+  pdbpp
+  hypothesis
+env =
+  MYPYPATH=./tox/mypy/bin/python
+commands =
+  mypy --py2 --silent-imports --check-untyped-defs --cache-dir {posargs:revex/}
+
 
 [flake8]
 ignore = E731,F811,E712,E127,E126,E226,E221

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ deps =
 env =
   MYPYPATH=./tox/mypy/bin/python
 commands =
-  mypy --py2 --silent-imports --check-untyped-defs --strict-optional {posargs:revex/}
   mypy --silent-imports --check-untyped-defs --strict-optional {posargs:revex/}
+  mypy --py2 --silent-imports --check-untyped-defs --strict-optional {posargs:revex/}
 
 [flake8]
 ignore = E731,F811,E712,E127,E126,E226,E221

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ deps =
 env =
   MYPYPATH=./tox/mypy/bin/python
 commands =
-  mypy --py2 --silent-imports --check-untyped-defs --strict-optional --warn-unused-ignores {posargs:revex/}
-  mypy --silent-imports --check-untyped-defs --strict-optional  --warn-unused-ignores {posargs:revex/}
+  mypy --py2 --silent-imports --check-untyped-defs --strict-optional --warn-unused-ignores --warn-redundant-casts {posargs:revex/}
+  mypy --silent-imports --check-untyped-defs --strict-optional  --warn-unused-ignores --warn-redundant-casts {posargs:revex/}
 
 [flake8]
 ignore = E731,F811,E712,E127,E126,E226,E221

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,7 @@ deps =
 env =
   MYPYPATH=./tox/mypy/bin/python
 commands =
-  mypy --py2 --silent-imports --check-untyped-defs --cache-dir {posargs:revex/}
-
+  mypy --py2 --silent-imports --check-untyped-defs {posargs:revex/}
 
 [flake8]
 ignore = E731,F811,E712,E127,E126,E226,E221

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ deps =
 env =
   MYPYPATH=./tox/mypy/bin/python
 commands =
-  mypy --py2 --silent-imports --check-untyped-defs {posargs:revex/}
-  mypy --silent-imports --check-untyped-defs {posargs:revex/}
+  mypy --py2 --silent-imports --check-untyped-defs --strict-optional {posargs:revex/}
+  mypy --silent-imports --check-untyped-defs --strict-optional {posargs:revex/}
 
 [flake8]
 ignore = E731,F811,E712,E127,E126,E226,E221

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ deps =
 env =
   MYPYPATH=./tox/mypy/bin/python
 commands =
-  mypy --silent-imports --check-untyped-defs --strict-optional {posargs:revex/}
-  mypy --py2 --silent-imports --check-untyped-defs --strict-optional {posargs:revex/}
+  mypy --py2 --silent-imports --check-untyped-defs --strict-optional --warn-unused-ignores {posargs:revex/}
+  mypy --silent-imports --check-untyped-defs --strict-optional  --warn-unused-ignores {posargs:revex/}
 
 [flake8]
 ignore = E731,F811,E712,E127,E126,E226,E221

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ env =
   MYPYPATH=./tox/mypy/bin/python
 commands =
   mypy --py2 --silent-imports --check-untyped-defs {posargs:revex/}
+  mypy --silent-imports --check-untyped-defs {posargs:revex/}
 
 [flake8]
 ignore = E731,F811,E712,E127,E126,E226,E221


### PR DESCRIPTION
Adds `mypy` and PEP-484 type hinting. It uses the "comment" syntax since this library is still Python 2 compatible.