### PR TITLE
Simplify and fix more escaping bugs

### DIFF
--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -548,9 +548,9 @@ REGEX = Grammar(r'''
         any /
         non_metachar
 
+    group = ("(?:" / "(") re ")"
     lookaround = "(" ("?=" / "?!" / "<=" / "<!") re ")"
     comment = "(?#" ("\)" / ~"[^)]")* ")"
-    group = ("(?:" / "(") re ")"
 
     escaped_character =
         escaped_metachar /
@@ -563,7 +563,7 @@ REGEX = Grammar(r'''
 
     any = "."
     charclass = "\\" ~"[dDwWsS]"
-    non_metachar = ~"[^.$^\\*+()|{?]"
+    non_metachar = ~"[^.$^\\*+()|?]"
     character_set = "[" "^"? set_items "]"
     set_char = escaped_numeric_character / ~"[^\\]]"
     escaped_set_char = ~"\\\\[[\\]-]"

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -559,7 +559,8 @@ REGEX = Grammar(r'''
     escaped_numeric_character =
         ("\\"  ~"[0-7]{3}") /
         ("\\x" ~"[0-9a-f]{2}"i) /
-        ("\\u" ~"[0-9a-f]{4}"i)
+        ("\\u" ~"[0-9a-f]{4}"i) /
+        ("\\U" ~"[0-9a-f]{8}"i)
 
     any = "."
     charclass = "\\" ~"[dDwWsS]"
@@ -645,7 +646,7 @@ class RegexVisitor(NodeVisitor):
         if escape == '\\':
             # Octal escape code like '\077'
             return chr(int(character_code, 8))
-        elif escape in ('\\u', '\\x'):
+        elif escape in ('\\u', '\\x', '\\U'):
             # hex escape like '\xff'
             return chr(int(character_code, 16))
         else:

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -598,10 +598,6 @@ class RegexVisitor(NodeVisitor):
         lparen, re, rparen = children
         return re
 
-    def visit_char(self, node, children):
-        [char] = children
-        return char
-
     def visit_charclass(self, node, children):
         slash, charclass = children
         return CharClass(charclass)
@@ -655,10 +651,6 @@ class RegexVisitor(NodeVisitor):
     def visit_escaped_set_char(self, node, children):
         slash, char = node.text
         return char
-
-    def visit_escaped_charcode(self, node, children):
-        [child] = children
-        return CharSet([child])
 
     def visit_non_metachar(self, node, children):
         return CharSet(node.text)

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -548,8 +548,8 @@ REGEX = Grammar(r'''
     escaped_metachar = "\\" ~"[.$^\\*+()|{}?\\]\\[]"
     escaped_numeric_character =
         ("\\"  ~"[0-7]{3}") /
-        ("\\x" ~"[0-9a-f]{2}") /
-        ("\\u" ~"[0-9a-f]{4}")
+        ("\\x" ~"[0-9a-f]{2}"i) /
+        ("\\u" ~"[0-9a-f]{4}"i)
 
     escaped_charcode = escaped_numeric_character / escaped_numeric_character
     any = "."

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -537,7 +537,17 @@ REGEX = Grammar(r'''
     quantified = literal ~"[*+?]"
     repeat_fixed = literal "{" ~"\d+" "}"
     repeat_range = literal "{" ~"(\d+)?" "," ~"(\d+)?" "}"
-    literal = comment / lookaround / group / character_set / char
+
+    literal =
+        comment /
+        lookaround /
+        group /
+        character_set /
+        escaped_character /
+        charclass /
+        any /
+        non_metachar
+
     lookaround = "(" ("?=" / "?!" / "<=" / "<!") re ")"
     comment = "(?#" ("\)" / ~"[^)]")* ")"
     group = ("(?:" / "(") re ")"
@@ -552,7 +562,6 @@ REGEX = Grammar(r'''
         ("\\u" ~"[0-9a-f]{4}"i)
 
     any = "."
-    char = escaped_character / charclass / any / non_metachar
     charclass = "\\" ~"[dDwWsS]"
     non_metachar = ~"[^.$^\\*+()|{?]"
     character_set = "[" "^"? set_items "]"

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -541,11 +541,17 @@ REGEX = Grammar(r'''
     lookaround = "(" ("?=" / "?!" / "<=" / "<!") re ")"
     comment = "(?#" ("\)" / ~"[^)]")* ")"
     group = ("(?:" / "(") re ")"
+
+    escaped_character =
+        escaped_metachar /
+        escaped_binary_hexcode /
+        escaped_octal /
+        escaped_unicode_hexcode
     escaped_metachar = "\\" ~"[.$^\\*+()|{}?\\]\\[]"
     escaped_binary_hexcode = "\\x" ~"[0-9a-f]{2}"
     escaped_octal = "\\" ~"[0-7]{3}"
     escaped_unicode_hexcode = "\\u" ~"[0-9a-f]{4}"
-    escaped_character = escaped_metachar / escaped_binary_hexcode / escaped_octal / escaped_unicode_hexcode
+
     escaped_charcode = escaped_binary_hexcode / escaped_unicode_hexcode / escaped_octal
     any = "."
     char = escaped_metachar / escaped_charcode / charclass / any / non_metachar

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -551,15 +551,14 @@ REGEX = Grammar(r'''
         ("\\x" ~"[0-9a-f]{2}"i) /
         ("\\u" ~"[0-9a-f]{4}"i)
 
-    escaped_charcode = escaped_numeric_character / escaped_numeric_character
     any = "."
-    char = escaped_metachar / escaped_charcode / charclass / any / non_metachar
+    char = escaped_character / charclass / any / non_metachar
     charclass = "\\" ~"[dDwWsS]"
     non_metachar = ~"[^.$^\\*+()|{?]"
     character_set = "[" "^"? set_items "]"
     set_char = escaped_numeric_character / ~"[^\\]]"
     escaped_set_char = ~"\\\\[[\\]-]"
-    set_items = (range / escaped_set_char / escaped_metachar / escaped_charcode / ~"[^\\]]" )+
+    set_items = (range / escaped_set_char / escaped_character / ~"[^\\]]" )+
     range = set_char  "-" set_char
 ''')  # noqa
 
@@ -624,9 +623,13 @@ class RegexVisitor(NodeVisitor):
         [child] = children
         return child
 
+    def visit_escaped_character(self, node, children):
+        [char] = children
+        return CharSet([char])
+
     def visit_escaped_metachar(self, node, children):
         slash, char = children
-        return CharSet([char])
+        return char
 
     def visit_escaped_numeric_character(self, node, children):
         [[escape, character_code]] = children

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -632,10 +632,10 @@ class RegexVisitor(NodeVisitor):
         [[escape, character_code]] = children
         if escape == '\\':
             # Octal escape code like '\077'
-            return chr(int(character_code.lstrip('0'), 8))
+            return chr(int(character_code, 8))
         elif escape in ('\\u', '\\x'):
             # hex escape like '\xff'
-            return chr(int(character_code.lstrip('0'), 16))
+            return chr(int(character_code, 16))
         else:
             raise NotImplementedError('Unhandled character escape %s' % escape)
 

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -147,6 +147,7 @@ def test_repeat():
     assert compile('ba{3}') == compile('baaa')
     assert compile('(ba){3}') == compile('bababa')
 
+    assert RE('{').match('{')
     assert RE('a{}').match('a{}')
 
 

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -204,6 +204,10 @@ def test_escaped_characters():
     assert RE(r'\x61\u0062\143').match('abc')
     assert RE(r'[\x61][\u0062][\143]').match('abc')
     assert RE(r'[\x61-\143]+').match('abc')
+    assert RE(r'\u00a3\u00A3').match('££')
+    assert RE(r'\x00').match('\x00')
+    assert RE(r'\u0000').match('\x00')
+    assert RE(r'\000').match('\x00')
 
     assert RE(r'[\)]').match(')')
     assert not RE(r'[\)]').match('\\')
@@ -216,7 +220,6 @@ def test_escaped_characters():
     assert RE(r'[\]]').match(']')
     assert RE(r'[a]\]').match('a]')
     assert RE(r'\{}').match('{}')
-    assert RE(r'\u00a3\u00A3').match('££')
 
 
 def test_escaped_character_range():

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import re
@@ -215,6 +216,7 @@ def test_escaped_characters():
     assert RE(r'[\]]').match(']')
     assert RE(r'[a]\]').match('a]')
     assert RE(r'\{}').match('{}')
+    assert RE(r'\u00a3\u00A3').match('££')
 
 
 def test_escaped_character_range():

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -208,6 +208,7 @@ def test_escaped_characters():
     assert RE(r'[\x61][\u0062][\143]').match('abc')
     assert RE(r'[\x61-\143]+').match('abc')
     assert RE(r'\u00a3\u00A3').match('££')
+    assert RE(r'\U0001f62b').match(u'😫')
     assert RE(r'\x00').match('\x00')
     assert RE(r'\u0000').match('\x00')
     assert RE(r'\000').match('\x00')

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -147,6 +147,8 @@ def test_repeat():
     assert compile('ba{3}') == compile('baaa')
     assert compile('(ba){3}') == compile('bababa')
 
+    assert RE('a{}').match('a{}')
+
 
 def test_character_class_space():
     assert RE(r'\s+').match('\n\t ')


### PR DESCRIPTION
This simplifies the grammar and fixes handling of:
- Escaped astral plane characters
- The NULL character (codepoint 0) escape code
- Octal literals which are not zero-padded
- `{` was being ignored when used as a character literal.
