### PR TITLE
Implement Lookaround

### DIFF
--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -548,7 +548,7 @@ REGEX = Grammar(r'''
         charclass /
         character
 
-    group = ("(?:" / "(") re ")"
+    group = ("(?:" / "(") !("?=" / "?!" / "<=" / "<!") re ")"
     lookaround = "(" ("?=" / "?!" / "<=" / "<!") re ")"
     comment = "(?#" ("\)" / ~"[^)]")* ")"
 
@@ -596,7 +596,7 @@ class RegexVisitor(NodeVisitor):
             'Lookaround expressions not implemented: %r' % node.text)
 
     def visit_group(self, node, children):
-        lparen, re, rparen = children
+        lparen, _, re, rparen = children
         return re
 
     def visit_charclass(self, node, children):

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -645,9 +645,10 @@ class PositiveLookAhead(LookAhead):
 
 REGEX = Grammar(r'''
     re = lookaround / union / concatenation
-    lookaround = (union / concatenation) "(" ("?=" / "?!" / "<=" / "<!") re ")" re
+    lookaround = (union / concatenation) "(" ("<=" / "?!" / "<!") re ")" re
+    lookahead = "(" "?=" re ")"
     union = (concatenation "|")+ concatenation
-    concatenation = (quantified / repeat_fixed / repeat_range / literal)*
+    concatenation = (lookahead / quantified / repeat_fixed / repeat_range / literal)*
     quantified = literal ~"[*+?]"
     repeat_fixed = literal "{" ~"\d+" "}"
     repeat_range = literal "{" ~"(\d+)?" "," ~"(\d+)?" "}"
@@ -704,6 +705,12 @@ class RegexVisitor(NodeVisitor):
         if assertion_type == "?=":
             return pre_re + PositiveLookAhead(lookaround_re, post_re)
         return LookAround(assertion_type, pre_re, lookaround_re, post_re)
+
+    def visit_lookahead(self, node, children):
+        # lookahead = "(" "?=" re ")"
+        lparen, quantifier, lookaround_re, rparen = children
+        assert (quantifier == "?="), 'not implemented'
+        return PositiveLookAhead(lookaround_re, EPSILON)
 
     def visit_comment(self, node, children):
         # Just ignore the comment text and return a zero-character regex.

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -238,7 +238,7 @@ class Concatenation(RegularExpression):
 
     @property
     def has_lookahead(self):  # type: () -> bool
-        return isinstance(self.children[-1], LookAhead)
+        return self.children[-1].has_lookahead
 
     @property
     def accepting(self):
@@ -466,7 +466,7 @@ class Union(RegularExpression):
 
     @property
     def has_lookahead(self):  # type: () -> bool
-        return any(isinstance(child, LookAhead) for child in self.children)
+        return any(child.has_lookahead for child in self.children)
 
     def __add__(self, other):
         lookaheads = tuple(r for r in self.children if r.has_lookahead)
@@ -518,7 +518,7 @@ class Complement(RegularExpression):
 
     @property
     def has_lookahead(self):  # type: () -> bool
-        return isinstance(self.regex, LookAhead)
+        return self.regex.has_lookahead
 
     @property
     def is_atomic(self):
@@ -557,7 +557,7 @@ class Star(RegularExpression):
 
     @property
     def has_lookahead(self):  # type: () -> bool
-        return isinstance(self.regex, LookAhead)
+        return self.regex.has_lookahead
 
     def derivative(self, char):  # type: (String) -> RegularExpression
         return self.regex.derivative(char) + self
@@ -615,6 +615,8 @@ class LookAhead(RegularExpression):
         instance.suffix = suffix
         instance.accepting = accepting
         return instance
+
+    has_lookahead = True
 
     def derivative(self, char):
         look_der = self.lookaround_re.derivative(char)

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -625,6 +625,7 @@ class LookAhead(RegularExpression):
         return 'LookAhead(%r, %r)' % (self.lookaround_re, self.post_re)
 
     def __str__(self):
+        # TODO: show negative lookahead as (?!...) instead of (?=~...)
         return '(?=%s)%s' % (self.lookaround_re, self.post_re)
 
     @property

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -599,23 +599,23 @@ class LookAhead(RegularExpression):
     lookaround_re = None  # type: RegularExpression
     post_re = None  # type: RegularExpression
 
-    def __new__(cls, lookaround_re, post_re):
+    def __new__(cls, lookaround_re, suffix):
         instance = super(LookAhead, cls).__new__(cls)
 
-        accepting = lookaround_re.accepting and post_re.accepting
-        if lookaround_re is EMPTY or post_re is EMPTY:
+        accepting = lookaround_re.accepting and suffix.accepting
+        if lookaround_re is EMPTY or suffix is EMPTY:
             # The lookahead condition has failed
             return EMPTY
         elif lookaround_re.accepting:
             # The lookahead condition has been satisfied
-            return post_re
+            return suffix
         # Note that if ``post_re is EPSILON``, we could simplify to just EMPTY,
         # but we don't to allow composing at group boundaries. For example:
         # /(foo(?=bar)).*/ is parsed as /(foo + (?=bar)) + .*/
         # Clearly /foo(?=bar)/ never matches any string.
 
         instance.lookaround_re = lookaround_re
-        instance.post_re = post_re
+        instance.post_re = suffix
         instance.accepting = accepting
         return instance
 
@@ -625,7 +625,7 @@ class LookAhead(RegularExpression):
         return LookAhead(look_der, post_der)
 
     def __repr__(self):
-        return 'PositiveLookAhead(%r, %r)' % (self.lookaround_re, self.post_re)
+        return 'LookAhead(%r, %r)' % (self.lookaround_re, self.post_re)
 
     def __str__(self):
         return '(?=%s)%s' % (self.lookaround_re, self.post_re)

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -674,7 +674,7 @@ class LookBehind(RegularExpression):
 
         accepting = prefix.accepting and lookaround_re.accepting
         if lookaround_re is EMPTY or prefix is EMPTY:
-            # The lookahead condition has failed
+            # The lookbehind condition has failed
             return EMPTY
 
         instance.lookaround_re = lookaround_re
@@ -688,7 +688,7 @@ class LookBehind(RegularExpression):
     def collapse_concatenation(cls, children):
         # type: (Tuple[RegularExpression, ...]) -> Tuple[RegularExpression, ...]
         """
-        Collapses LookAhead assertions from the right.
+        Collapses LookBehind assertions from the left.
         """
         if len(children) < 2 or isinstance(children[0], LookBehind):
             return children
@@ -712,7 +712,7 @@ class LookBehind(RegularExpression):
 
     def __str__(self):
         # TODO: show negative lookbehind as (<!...) instead of (<=~...)
-        return '%s(<=%s)' % (self.prefix, self.lookaround_re)
+        return '%s(?<=%s)' % (self.prefix, self.lookaround_re)
 
     @property
     def identity_tuple(self):

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -577,8 +577,10 @@ class PositiveLookAhead(LookAhead):
         elif lookaround_re.accepting:
             # The lookahead condition has been satisfied
             return post_re
-        elif post_re is EPSILON:
-            return EMPTY
+        # Note that if ``post_re is EPSILON``, we could simplify to just EMPTY,
+        # but we don't to allow composing at group boundaries. For example:
+        # /(foo(?=bar)).*/ is parsed as /(foo + (?=bar)) + .*/
+        # Clearly /foo(?=bar)/ never matches any string.
 
         instance.lookaround_re = lookaround_re
         instance.post_re = post_re

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -201,12 +201,12 @@ def test_lookaround_grammar():
     RE(r'foo(?=bar).*')
 
 
-@pytest.mark.xfail(reason='TODO: https://github.com/lucaswiman/revex/issues/6')
 def test_lookaround_match():
     assert RE(r'foo(?=bar).*').match('foobarasdf')
     assert RE(r'foo(?=bar).*').match('foobar')
     assert not RE(r'foo(?!bar).*').match('foobar')
     assert RE(r'foo(?!bar).*').match('foobaz')
+    assert RE(r'(a(?=bar).).*(?=baz).*').match('abarbbaz')
     # TODO: see `test_empty` above.
     # assert not RE(r'foo(?=bar)').match('foobar')
 

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -207,9 +207,11 @@ def test_lookaround_match():
     assert not RE(r'foo(?=bar)').match('foobar')
 
 
-@pytest.mark.xfail(reason='TODO: https://github.com/lucaswiman/revex/issues/6')
 def test_grouped_lookaround():
     assert RE(r'(a(?=bar).).*(?=baz).*').match('abarbbaz')
+    assert RE(r'(a(?=bar)).*(?=baz).*').match('abarbbaz')
+    assert RE(r'a(a(?=bar)|c).*').match('ac')
+    assert RE(r'a(a(?=bar)|c).*').match('aabar')
 
 
 def test_escaped_characters():

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -212,6 +212,12 @@ def test_grouped_lookaround():
     assert RE(r'a(a(?=bar)|c).*').match('ac')
     assert RE(r'a(a(?=bar)|c).*').match('aabar')
 
+    assert not RE(r'(a(?!bar).).*(?=baz).*').match('abarbbaz')
+    assert not RE(r'(a(?!bar)).*(?=baz).*').match('abarbbaz')
+    assert RE(r'a((a(?!bar))|c).*').match('ac')
+    assert RE(r'a(a(?!bar)|c).*').match('ac')
+    assert not RE(r'a(a(?!bar)|c).*').match('aabar')
+
 
 def test_escaped_characters():
     assert 'a' == '\x61'

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -192,8 +192,8 @@ def test_lookaround_grammar():
     assert REGEX.parse(r'foo(?=bar)')
     assert REGEX.parse(r'foo(?=(ab)*)')
     assert REGEX.parse(r'foo(?!bar)')
-    assert REGEX.parse(r'.*(<=bar)foo')
-    assert REGEX.parse(r'.*(<!bar)foo')
+    assert REGEX.parse(r'.*(?<=bar)foo')
+    assert REGEX.parse(r'.*(?<!bar)foo')
     RE(r'foo(?=bar).*')
 
 
@@ -204,7 +204,8 @@ def test_lookaround_match():
     assert RE(r'foo(?!bar).*').match('foobaz')
     assert not RE(r'foo(?=bar)').match('foobar')
 
-    assert RE(r'foo(<=foo).*').match('foobar')
+    assert RE(r'.*(?<=foo)bar').match('foobar')
+    assert not RE(r'.*(?<=foo)bar').match('foodbar')
 
 
 def test_grouped_lookaround():

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 
 import re
 
-import pytest
-
 from revex import compile
 from revex.derivative import REGEX, EPSILON
 

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -210,6 +210,7 @@ def test_lookaround_match():
 def test_grouped_lookaround():
     assert RE(r'(a(?=bar).).*(?=baz).*').match('abarbbaz')
     assert RE(r'(a(?=bar)).*(?=baz).*').match('abarbbaz')
+    assert RE(r'a((a(?=bar))|c).*').match('ac')
     assert RE(r'a(a(?=bar)|c).*').match('ac')
     assert RE(r'a(a(?=bar)|c).*').match('aabar')
 

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -192,20 +192,23 @@ def test_noncapturing_group():
 
 def test_lookaround_grammar():
     assert REGEX.parse(r'foo(?=bar).*')
-    assert REGEX.parse(r'foo(?=bar)')
-    assert REGEX.parse(r'foo(?=(ab)*)')
-    assert REGEX.parse(r'foo(?!bar)')
+    # TODO: see `test_empty` above.
+    # assert REGEX.parse(r'foo(?=bar)')
+    # assert REGEX.parse(r'foo(?=(ab)*)')
+    # assert REGEX.parse(r'foo(?!bar)')
     assert REGEX.parse(r'.*(<=bar)foo')
     assert REGEX.parse(r'.*(<!bar)foo')
-    with pytest.raises(VisitationError):
-        RE(r'foo(?=bar).*')
+    RE(r'foo(?=bar).*')
 
 
 @pytest.mark.xfail(reason='TODO: https://github.com/lucaswiman/revex/issues/6')
 def test_lookaround_match():
     assert RE(r'foo(?=bar).*').match('foobarasdf')
     assert RE(r'foo(?=bar).*').match('foobar')
-    assert not RE(r'foo(?=bar)').match('foobar')
+    assert not RE(r'foo(?!bar).*').match('foobar')
+    assert RE(r'foo(?!bar).*').match('foobaz')
+    # TODO: see `test_empty` above.
+    # assert not RE(r'foo(?=bar)').match('foobar')
 
 
 def test_escaped_characters():

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -207,6 +207,9 @@ def test_lookaround_match():
     assert RE(r'.*(?<=foo)bar').match('foobar')
     assert not RE(r'.*(?<=foo)bar').match('foodbar')
 
+    assert not RE(r'.*(?<!foo)bar').match('foobar')
+    assert RE(r'.*(?<!foo)bar').match('foodbar')
+
 
 def test_grouped_lookaround():
     assert RE(r'(a(?=bar).).*(?=baz).*').match('abarbbaz')

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import re
 
 import pytest
-from parsimonious import VisitationError
 
 from revex import compile
 from revex.derivative import REGEX, EPSILON
@@ -192,10 +191,9 @@ def test_noncapturing_group():
 
 def test_lookaround_grammar():
     assert REGEX.parse(r'foo(?=bar).*')
-    # TODO: see `test_empty` above.
-    # assert REGEX.parse(r'foo(?=bar)')
-    # assert REGEX.parse(r'foo(?=(ab)*)')
-    # assert REGEX.parse(r'foo(?!bar)')
+    assert REGEX.parse(r'foo(?=bar)')
+    assert REGEX.parse(r'foo(?=(ab)*)')
+    assert REGEX.parse(r'foo(?!bar)')
     assert REGEX.parse(r'.*(<=bar)foo')
     assert REGEX.parse(r'.*(<!bar)foo')
     RE(r'foo(?=bar).*')
@@ -206,9 +204,12 @@ def test_lookaround_match():
     assert RE(r'foo(?=bar).*').match('foobar')
     assert not RE(r'foo(?!bar).*').match('foobar')
     assert RE(r'foo(?!bar).*').match('foobaz')
+    assert not RE(r'foo(?=bar)').match('foobar')
+
+
+@pytest.mark.xfail(reason='TODO: https://github.com/lucaswiman/revex/issues/6')
+def test_grouped_lookaround():
     assert RE(r'(a(?=bar).).*(?=baz).*').match('abarbbaz')
-    # TODO: see `test_empty` above.
-    # assert not RE(r'foo(?=bar)').match('foobar')
 
 
 def test_escaped_characters():

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -204,6 +204,8 @@ def test_lookaround_match():
     assert RE(r'foo(?!bar).*').match('foobaz')
     assert not RE(r'foo(?=bar)').match('foobar')
 
+    assert RE(r'foo(<=foo).*').match('foobar')
+
 
 def test_grouped_lookaround():
     assert RE(r'(a(?=bar).).*(?=baz).*').match('abarbbaz')


### PR DESCRIPTION
This PR implements #6 by adding support for positive and negative lookahead and lookbehind. The approach is fairly ugly, since these features are "nonlocal" in the parse tree, and do not compose nicely with standard operations in the Kleene algebra regular expressions are based on.

The general approach described [here](http://cs.stackexchange.com/questions/38451/when-a-regexp-is-not-a-regular-expression), of implementing a lookahead assertion as an extended regular expression suffices to show that they are regular. For example, `foo(?!bar)[ba]*` can be rewritten ast `foo((bar.*)&([ba]*))` and is clearly equivalent to the empty language. However, appending the string literal `r` leads to a problem: 
- `(foo(?!bar)[ba]*)r`  (matches the string `foobar`)
- `(foo((bar.*)&([ba]*)))r` (is empty)

Here we attempt to rewrite some terms (concatenation, union, etc) so that they compose correctly. The approach is ugly, and I think the implementation is plausibly quite buggy, but this is a reasonable stopping place.  I'll try to revisit correctness of more complex expressions at a later date, when hopefully some simplifications will jump out at me.