### PR TITLE
Fix overflow

### DIFF
--- a/revex/generation.py
+++ b/revex/generation.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division
 
-import random
 import itertools
+import math
+import random
 from bisect import bisect_left
 from itertools import count
 
@@ -21,6 +22,28 @@ class InvalidDistributionError(Exception):
 
 class _Distribution(list):
     pass
+
+
+def nplog(x):
+    """
+    Like math.log, but has sensible behavior at 0.
+
+    Similar to numpy.log.
+    """
+    if x == 0.0:
+        return float('-inf')
+    else:
+        return math.log(x)
+
+
+def logsumexp(xs):  # type: (List[float]) -> float
+    """
+    See https://en.wikipedia.org/wiki/LogSumExp
+    """
+    m = max(xs)
+    if m == float('-inf'):
+        return float('-inf')
+    return m + nplog(sum((math.exp(x - m) for x in xs), 0.0))
 
 
 class DiscreteRandomVariable(_Distribution):

--- a/revex/generation.py
+++ b/revex/generation.py
@@ -48,11 +48,11 @@ def logsumexp(xs):  # type: (List[float]) -> float
 
 class DiscreteRandomVariable(_Distribution):
     def __init__(self, counts):  # type: (List[float]) -> None
-        total = sum(counts, 0.0)
-        if total == 0:
+        total = logsumexp(counts)
+        if total == float('-inf'):
             raise InvalidDistributionError()
         super(DiscreteRandomVariable, self).__init__(
-            count / total for count in counts)
+            math.exp(count - total) for count in counts)
         for i in range(1, len(self)):
             # Build the right endpoints to sample from.
             self[i] += self[i - 1]
@@ -74,7 +74,7 @@ class LeastFrequentRoundRobin(_Distribution):
     """
     def __init__(self, counts):  # type: (List[Union[float, int]]) -> None
         super(LeastFrequentRoundRobin, self).__init__(
-            i for i, count in enumerate(counts) if counts[i] > 0)
+            i for i, count in enumerate(counts) if counts[i] > nplog(0))
         self.sort(key=counts.__getitem__)  # Sort indices from least to most frequent.
         self.chooser = itertools.cycle(self)
 
@@ -100,7 +100,7 @@ class PathCounts(list):
         # state to an accepting state. (i.e. 1 if the state is accepting.)
         self.states = range(len(self.dfa.node))
         super(PathCounts, self).__init__(
-            [1.0 if self.dfa.node[state]['accepting'] else 0.0]
+            [nplog(1.0) if self.dfa.node[state]['accepting'] else nplog(0.0)]
             for state in self.states
         )
         self.longest_path_length = 0
@@ -115,9 +115,9 @@ class PathCounts(list):
                     # Compute the next length of paths by summing the number of
                     # paths of length self.longest_path_length among the out-edges
                     # of the node.
-                    path_counts = math.exp(logsumexp([
-                        nplog(self[self.dfa.delta[state][char]][self.longest_path_length])
-                        for char in self.dfa.alphabet]))
+                    path_counts = logsumexp([
+                        self[self.dfa.delta[state][char]][self.longest_path_length]
+                        for char in self.dfa.alphabet])
                     self[state].append(path_counts)
                 self.longest_path_length += 1
             return self[node][path_length]
@@ -170,7 +170,7 @@ class BaseGenerator(object):
         chars = []
         if length == 0 and not self.dfa.node[state]['accepting']:
             return None
-        elif self.path_counts[state, length] == 0:
+        elif self.path_counts[state, length] == nplog(0):
             return None  # No paths of the given length.
         for i in range(length):
             dist = self.get_dist_for_node_and_length(state, length - i)
@@ -192,7 +192,7 @@ class BaseGenerator(object):
             iterator = count()
 
         for length in iterator:
-            if self.path_counts[self.dfa.start, length] > 0:
+            if self.path_counts[self.dfa.start, length] > nplog(0):
                 yield length
 
 

--- a/revex/generation.py
+++ b/revex/generation.py
@@ -115,9 +115,9 @@ class PathCounts(list):
                     # Compute the next length of paths by summing the number of
                     # paths of length self.longest_path_length among the out-edges
                     # of the node.
-                    path_counts = sum(
-                        self[self.dfa.delta[state][char]][self.longest_path_length]
-                        for char in self.dfa.alphabet)
+                    path_counts = math.exp(logsumexp([
+                        nplog(self[self.dfa.delta[state][char]][self.longest_path_length])
+                        for char in self.dfa.alphabet]))
                     self[state].append(path_counts)
                 self.longest_path_length += 1
             return self[node][path_length]

--- a/revex/tests/test_generation.py
+++ b/revex/tests/test_generation.py
@@ -2,6 +2,8 @@ from __future__ import division
 import re
 from collections import Counter
 from itertools import islice
+from sys import float_info
+import math
 
 import pytest
 
@@ -159,3 +161,14 @@ def test_random_walk_matches_regex(regex):
             rand_string = gen.generate_string(length)
             assert actual.match(rand_string), '%s should match %s' % (regex, rand_string)
             assert revex_regex.match(rand_string), '%s should match %s' % (regex, rand_string)
+
+
+def test_overflow_example():
+    # Regression test for float overflow in computing the probability
+    # distribution.
+    bits = int(math.ceil(math.log(float_info.max) / math.log(2))) - 1
+    assert (2. ** bits) * 2. == float('inf')
+    actual = re.compile(r'^[01]+$')
+    revex_regex = revex.compile(r'[01]+')
+    gen = rgen(revex_regex, alphabet=list('01'))
+    assert actual.match(gen.generate_string(bits + 1))

--- a/revex/tests/test_generation.py
+++ b/revex/tests/test_generation.py
@@ -175,6 +175,7 @@ def test_overflow_example():
     revex_regex = revex.compile(r'[01]+')
     gen = rgen(revex_regex, alphabet=list('01'))
     assert actual.match(gen.generate_string(bits + 1))
+    assert actual.match(gen.generate_string(bits * 2))
 
 
 def assert_same_significant_digits(a, b, digits):


### PR DESCRIPTION
This PR fixes an issue with generating long strings caused by floating point overflow. In the example below, the path counts slightly exceed the largest representable floating point number

```python
>>> from revex.generation import RandomRegularLanguageGenerator
>>> from revex import compile
>>> 
>>> gen = RandomRegularLanguageGenerator(compile(r'[01]+').as_dfa())
>>> gen.generate_string(1023)
'101101011000000101101100100000101100001001111010111101001010111110011111010100000010010110101010001000010010110100001000010000001000110100100010001001011100000101111010100000000011011000010100001101010111101110000011001001110011110111101111011000101000100000111110110000001100111111010111111101111011111001011001001011111111100101100101101010101110010100011111001100111110100100111011111101010000110001111110111000010011010110001110001001011001010101100000000111000011101010011101011111100010010111011010011001101000010010011101100001110111010011001001100100111110110001000011001111101101100011000000010111010001111111110110010101011110110011001010000010011110101011101111000110001000011101000100101100010011011000000001010000110101011011001010101010001001101001111100101001110110101100111011011101111110001110100001010110101100101010100001011111100100010111001111111110101110111010011001101101010101101010001011000010001001110001000011110011110101111101011011101010111011110110010101001000101110100110010010000010010101101'
>>> gen.generate_string(1024)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/lucaswiman/opensource/revex/revex/generation.py", line 156, in generate_string
    char = self.alphabet[dist.draw()]
IndexError: list index out of range
```

## Changes
To fix this, I store the counts of walks in the DFA on a logarithmic scale, using the [LogSumExp](https://en.wikipedia.org/wiki/LogSumExp) function to prevent overflow. This bespoke implementation of this should be removed if/when numpy or sympy is ever added as a dependency.