### PR TITLE
Adjacency power

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ networkx
 parsimonious>=0.7.0
 six
 pygraphviz
+numpy

--- a/revex/generation.py
+++ b/revex/generation.py
@@ -61,87 +61,47 @@ class LeastFrequentRoundRobin(_Distribution):
         return next(self.chooser)
 
 
-class PathWeights(list):
+class PathWeights(object):
 
     def __init__(self, dfa):  # type: (DFA) -> None
         """
         Class for maintaining state path weights inside a dfa.
 
         This is a renormalized version of l_{p,n} in section 2 of the Bernardi
-        & Giménez paper, path_weights[state][n] is the proportion of paths of
+        & Giménez paper, computed using matrix powers. See:
+        https://en.wikipedia.org/wiki/Adjacency_matrix#Matrix_powers
+
+        Note that ``path_weights[state, n]`` is the proportion of paths of
         length n from state to _some_ final/accepting state.
 
         `dfa` MUST have consecutive integer states, with 0 as the start state,
         though this is not validated.
         """
-        self.dfa = dfa
-        # Initialize the array with the number of zero-length paths from the
-        # state to an accepting state. (i.e. 1 if the state is accepting.)
-        self.states = range(len(self.dfa.node))
-        number_of_accepting_states = sum(
-            self.dfa.node[state]['accepting'] for state in self.states) or 1.0
-        super(PathWeights, self).__init__(
-            # Note that True == 1 and False == 0.
-            [self.dfa.node[state]['accepting'] / number_of_accepting_states]
-            for state in self.states
-        )
         self.longest_path_length = 0
 
-        self.graph = self.dfa.as_multidigraph
-        self.sink = len(self.dfa.nodes())
+        self.graph = dfa.as_multidigraph
+        self.sink = len(dfa.nodes())
 
-        for state in self.dfa.nodes():
-            if self.dfa.node[state]['accepting']:
+        for state in dfa.nodes():
+            if dfa.node[state]['accepting']:
                 self.graph.add_edge(state, self.sink)
 
-        self.matrix = nx.to_numpy_matrix(
-            self.graph,
-            nodelist=self.graph.nodes(),
-        )
+        self.matrix = nx.to_numpy_matrix(self.graph, nodelist=self.graph.nodes())
         vect = np.zeros(self.matrix.shape[0])
-        vect[-1] = 1.0  # Grab the neighborhood of the sink node (last column).
-        vect = self.normalize_vector(self.matrix.dot(vect)).T
-        self.vects = [vect]
+        vect[-1] = 1.0  # Grabs the neighborhood of the sink node (last column).
+        self.vects = [self.normalize_vector(self.matrix.dot(vect)).T]
 
     @staticmethod
     def normalize_vector(vector):
-        import numpy as np
         total = np.sum(vector)
-        assert not np.isnan(total)
-        if total == 0:
-            return vector
-        else:
-            return vector / total
+        return vector if total == 0 else vector / total
 
     def __getitem__(self, item):
-        if isinstance(item, tuple):
-            node, path_length = item
-            while path_length > self.longest_path_length:
-                # Precomputes all path lengths up to path_length by expanding
-                # breadth first search.
-                total = 0.0
-                for state in self.states:
-                    # Compute the next length of paths by summing the number of
-                    # paths of length self.longest_path_length among the out-edges
-                    # of the node.
-                    path_weight = sum(
-                        self[self.dfa.delta[state][char]][self.longest_path_length]
-                        for char in self.dfa.alphabet)
-                    total += path_weight
-                    self[state].append(path_weight)
-                self.longest_path_length += 1
-                for state in self.states:
-                    if total > 0:
-                        self[state][self.longest_path_length] /= total
-                self.vects.append(self.normalize_vector(self.matrix.dot(self.vects[-1])))
-            old_ret = self[node][path_length]
-            new_ret = self.vects[path_length].item(node)
-            assert abs(old_ret - new_ret) < 0.001
-            return new_ret
-        return list.__getitem__(self, item)
-
-    def __repr__(self):
-        return 'PathWeights(%r)' % self.dfa
+        node, path_length = item
+        while path_length > self.longest_path_length:
+            self.longest_path_length += 1
+            self.vects.append(self.normalize_vector(self.matrix.dot(self.vects[-1])))
+        return self.vects[path_length].item(node)
 
 
 class BaseGenerator(object):
@@ -154,7 +114,7 @@ class BaseGenerator(object):
         self.nodes = range(0, len(self.dfa.node))
 
         # Denoted by l_{p,n} in section 2 of the Bernardi & Giménez paper,
-        # path_weights[state][n] is the proportion of paths of length n from
+        # path_weights[state, n] is the proportion of paths of length n from
         # state to _some_ final/accepting state. In that paper, the _counts_ are
         # stored as floating point numbers for efficiency, but this leads to
         # overflow when generating very long strings. In our implementation, the

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='revex',
       author_email='lucas.wiman@gmail.com',
       license='Apache 2.0',
       packages=['revex'],
-      install_requires=['parsimonious', 'networkx', 'six'],
+      install_requires=['parsimonious', 'networkx', 'six', 'numpy'],
       long_description='foo',
       zip_safe=False)

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ deps =
 env =
   MYPYPATH=./tox/mypy/bin/python
 commands =
-  mypy --py2  --ignore-missing-imports --follow-imports=skip --check-untyped-defs --strict-optional --warn-unused-ignores --warn-redundant-casts {posargs:revex/}
-  mypy  --ignore-missing-imports --follow-imports=skip --check-untyped-defs --strict-optional {posargs:revex/}
+  mypy --py2  --show-traceback --ignore-missing-imports --follow-imports=skip --check-untyped-defs --strict-optional --warn-unused-ignores --warn-redundant-casts {posargs:revex/}
+  mypy  --show-traceback --ignore-missing-imports --follow-imports=skip --check-untyped-defs --strict-optional {posargs:revex/}
 
 [flake8]
 ignore = E731,F811,E712,E127,E126,E226,E221


### PR DESCRIPTION
This PR uses the [following theorem](https://en.wikipedia.org/wiki/Adjacency_matrix#Matrix_powers), which can be proved by induction:

> Let A be the adjacency matrix of a directed graph D, where A<sub>ij</sub> is the number of edges from i to j. Then (A<sup>n</sup>)<sub>ij</sub> is the count of walks from i to j.

This is somewhat simpler than what I was doing previously, since I realized that the old method was basically writing out these matrix multiplications in a complicated fashion using inefficient, bespoke Python instead of optimized native code. It's also about twice as fast on first generation of a string, and a bit faster on subsequent generation, since we can do a lot of the work in numpy.

If it weren't for overflow, this would make using the "divide and conquer" methods of the Bernardi & Giménez paper simpler to implement. I might be able to to use the normalization technique I currently use after each squaring, but that requires a proof I haven't thought through yet.

## Benchmarks

### this branch
```
In [1]: %paste
>>> from revex import compile
>>> from revex.generation import RandomRegularLanguageGenerator
>>> from collections import Counter
>>> import random
>>> d20 = compile(r'((0[1-9]|1[0-9]|20),)*(0[1-9]|1[0-9]|20)')
>>> gen = RandomRegularLanguageGenerator(d20.as_dfa(',0123456789'))

## -- End pasted text --

In [2]: %time rolls = gen.generate_string(3 * 20000 - 1)
CPU times: user 2.2 s, sys: 53.9 ms, total: 2.25 s
Wall time: 2.26 s

In [3]: %time rolls = gen.generate_string(3 * 20000 - 1)
CPU times: user 299 ms, sys: 6.37 ms, total: 305 ms
Wall time: 312 ms
```

### master
```
In [1]: %paste
>>> from revex import compile
>>> from revex.generation import RandomRegularLanguageGenerator
>>> from collections import Counter
>>> import random
>>> d20 = compile(r'((0[1-9]|1[0-9]|20),)*(0[1-9]|1[0-9]|20)')
>>> gen = RandomRegularLanguageGenerator(d20.as_dfa(',0123456789'))

## -- End pasted text --

In [2]: %time rolls = gen.generate_string(3 * 20000 - 1)
CPU times: user 5.71 s, sys: 45.2 ms, total: 5.76 s
Wall time: 5.78 s

In [3]: %time rolls = gen.generate_string(3 * 20000 - 1)
CPU times: user 423 ms, sys: 6.93 ms, total: 429 ms
Wall time: 436 ms
```