### PR TITLE
Accidentally quadratic example

### DIFF
--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -20,6 +20,8 @@ from typing import Sequence  # noqa
 from typing import Tuple  # noqa
 
 import six
+from six import unichr as chr
+
 from parsimonious import NodeVisitor, Grammar
 
 from revex.dfa import String, DFA  # noqa
@@ -872,9 +874,7 @@ class RegexVisitor(NodeVisitor):
 
     def visit_range(self, node, children):
         start, dash, end = children
-        return reduce(
-            operator.or_,
-            [CharSet([chr(i)]) for i in range(ord(start), ord(end) + 1)])
+        return CharSet([chr(i) for i in range(ord(start), ord(end) + 1)])
 
     def visit_set_items(self, node, children):
         items = [

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -273,3 +273,12 @@ def test_email_validation_example():
     # validation regex from http://emailregex.com/
     regex = r'''(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])'''   # noqa
     assert RE(regex).match('foo@bar.com')
+
+
+def test_url_validation_example():
+    # Regression test for severe performance bug discovered when examining a
+    # URL validation regex from https://mathiasbynens.be/demo/url-regex
+    # (@diegoperini)
+    regex = r'(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:/[^\s]*)?'  # noqa
+    assert REGEX.parse(regex)
+    assert RE(regex).match('http://foo.com/bar')


### PR DESCRIPTION
While investigating illustrative examples for the README, I found a regex that was taking forever to finish. Of course, storing a character range as a tuple of unicode characters is fairly inefficient, but to top it off, it was #AccidentallyQuadratic, with some fairly slow `__new__` hackery. It's still _pretty_ slow, but it's at least manageable now.