### PR TITLE
Add code for displaying diagrams in an ipython notebook

### DIFF
--- a/revex/dfa.py
+++ b/revex/dfa.py
@@ -257,7 +257,7 @@ class DFA(Generic[NodeType], nx.MultiDiGraph):
                 nx.drawing.nx_agraph.write_dot(graph, dotpath)
                 os.system(
                     'dot -Tpng {dotpath} -o {pngpath}'.format(**locals()))
-                with open(pngpath, 'rb') as f:
+                with open(pngpath, 'rb') as f:  # type: ignore
                     IPython.display.display(IPython.display.Image(data=f.read()))
             finally:
                 shutil.rmtree(directory)

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     pytest-cov
     typing
     ipython
+    jupyter
     pdbpp
     hypothesis
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -60,5 +60,5 @@ commands =
   mypy  --show-traceback --ignore-missing-imports --follow-imports=skip --check-untyped-defs --strict-optional {posargs:revex/}
 
 [flake8]
-ignore = E731,F811,E712,E127,E126,E226,E221
+ignore = E731,F811,E712,E127,E126,E226,E221,E401
 max-line-length = 100


### PR DESCRIPTION
This is instead of an OS-X only hack. The OS X hack still works, but this is at least more general.

Refs #19.