### PR TITLE
Fix charset parsing and character escaping

### DIFF
--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -22,7 +22,7 @@ from typing import Tuple  # noqa
 import six
 from six import unichr as chr
 
-from parsimonious import NodeVisitor, Grammar
+from parsimonious import NodeVisitor
 
 from revex.dfa import String, DFA  # noqa
 from revex.regex_grammar import REGEX

--- a/revex/derivative.py
+++ b/revex/derivative.py
@@ -25,6 +25,7 @@ from six import unichr as chr
 from parsimonious import NodeVisitor, Grammar
 
 from revex.dfa import String, DFA  # noqa
+from revex.regex_grammar import REGEX
 from .dfa import DEFAULT_ALPHABET
 
 
@@ -719,48 +720,6 @@ class LookBehind(RegularExpression):
     @property
     def identity_tuple(self):
         return (type(self).__name__, self.prefix, self.lookaround_re)
-
-
-REGEX = Grammar(r'''
-    re = union / concatenation
-    lookahead = "(" ("?=" / "?!" / "?<=" / "?<!") re ")"
-    union = (concatenation "|")+ concatenation
-    concatenation = (lookahead / quantified / repeat_fixed / repeat_range / literal)*
-    quantified = literal ~"[*+?]"
-    repeat_fixed = literal "{" ~"\d+" "}"
-    repeat_range = literal "{" ~"(\d+)?" "," ~"(\d+)?" "}"
-
-    literal =
-        comment /
-        group /
-        character_set /
-        escaped_character /
-        charclass /
-        character
-
-    group = ("(?:" / "(") !("?=" / "?!" / "?<=" / "?<!") re ")"
-    comment = "(?#" ("\)" / ~"[^)]")* ")"
-
-    escaped_character =
-        escaped_metachar /
-        escaped_numeric_character /
-        escaped_whitespace
-    escaped_metachar = "\\" ~"[.$^\\\\*+()|{}?\\][]"
-    escaped_numeric_character =
-        ("\\"  ~"[0-7]{3}") /
-        ("\\x" ~"[0-9a-f]{2}"i) /
-        ("\\u" ~"[0-9a-f]{4}"i) /
-        ("\\U" ~"[0-9a-f]{8}"i)
-    escaped_whitespace = "\\" ~"[ntvr]"
-
-    charclass = "\\" ~"[dDwWsS]"
-    character = ~"[^$^\\*+()|?]"
-    character_set = "[" "^"? set_items "]"
-    set_char = escaped_numeric_character / ~"[^\\]]"
-    escaped_set_char = ~"\\\\[[\\]-]"
-    set_items = (range / escaped_set_char / escaped_character / ~"[^\\]]" )+
-    range = set_char  "-" set_char
-''')  # noqa
 
 
 class RegexVisitor(NodeVisitor):

--- a/revex/regex_grammar.py
+++ b/revex/regex_grammar.py
@@ -11,7 +11,7 @@ def double_regex_escape(char):
     # regex inside a parsimonious grammar, so we escape odd characters to
     # their hex representation rather than just using "\\".
     if re.escape(char) != char:
-        return '\\x%0.2X' % ord(char)
+        return '\\\\x%0.2X' % ord(char)
     else:
         return char
 

--- a/revex/regex_grammar.py
+++ b/revex/regex_grammar.py
@@ -1,0 +1,50 @@
+from __future__ import unicode_literals
+
+import re, string
+
+from parsimonious import Grammar
+
+def is_char_escapable_in_ranges(char):  # type: (str) -> bool
+    return not re.compile(r'[\{char}]'.format(char=char)).match('\\')
+
+
+REGEX = Grammar(r'''
+    re = union / concatenation
+    lookahead = "(" ("?=" / "?!" / "?<=" / "?<!") re ")"
+    union = (concatenation "|")+ concatenation
+    concatenation = (lookahead / quantified / repeat_fixed / repeat_range / literal)*
+    quantified = literal ~"[*+?]"
+    repeat_fixed = literal "{" ~"\d+" "}"
+    repeat_range = literal "{" ~"(\d+)?" "," ~"(\d+)?" "}"
+
+    literal =
+        comment /
+        group /
+        character_set /
+        escaped_character /
+        charclass /
+        character
+
+    group = ("(?:" / "(") !("?=" / "?!" / "?<=" / "?<!") re ")"
+    comment = "(?#" ("\)" / ~"[^)]")* ")"
+
+    escaped_character =
+        escaped_metachar /
+        escaped_numeric_character /
+        escaped_whitespace
+    escaped_metachar = "\\" ~"[.$^\\\\*+()|{}?\\][/]"
+    escaped_numeric_character =
+        ("\\"  ~"[0-7]{3}") /
+        ("\\x" ~"[0-9a-f]{2}"i) /
+        ("\\u" ~"[0-9a-f]{4}"i) /
+        ("\\U" ~"[0-9a-f]{8}"i)
+    escaped_whitespace = "\\" ~"[ntvr]"
+
+    charclass = "\\" ~"[dDwWsS]"
+    character = ~"[^$^\\*+()|?]"
+    character_set = "[" "^"? set_items "]"
+    set_char = escaped_numeric_character / ~"[^\\]]"
+    escaped_set_char = ~"\\\\[[\\]-]"
+    set_items = (range / escaped_set_char / escaped_character / ~"[^\\]]" )+
+    range = set_char  "-" set_char
+''')  # noqa

--- a/revex/regex_grammar.py
+++ b/revex/regex_grammar.py
@@ -11,8 +11,10 @@ from parsimonious import Grammar
 # the list is correct.
 if sys.version_info < (3, ):
     ESCAPABLE_CHARS = '0abcdefghijklmnopqrstuvwyzCEFGHIJKLMNOPQRTUVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^\\_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
+    CHARSET_ESCAPABLE_CHARS = '0abcdefghijklmnopqrstuvwyzCEFGHIJKLMNOPQRTUVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^\\_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
 else:
     ESCAPABLE_CHARS = '0abcdefghijklmnopqrstvwyzCEFGHIJKLMNOPQRTVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
+    CHARSET_ESCAPABLE_CHARS = '0abcdefghijklmnopqrstvwyzCEFGHIJKLMNOPQRTVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
 
 
 REGEX = Grammar(r'''
@@ -54,4 +56,4 @@ REGEX = Grammar(r'''
     escaped_set_char = "\\" ~"[%s]"
     set_items = (range / escaped_set_char / escaped_character / ~"[^\\]]" )+
     range = set_char  "-" set_char
-''' % ESCAPABLE_CHARS)  # noqa
+''' % CHARSET_ESCAPABLE_CHARS)  # noqa

--- a/revex/regex_grammar.py
+++ b/revex/regex_grammar.py
@@ -1,8 +1,19 @@
 from __future__ import unicode_literals
 
+import re
 import sys
 
 from parsimonious import Grammar
+
+
+def double_regex_escape(char):
+    # This works around the fact that we're trying to include this as a
+    # regex inside a parsimonious grammar, so we escape odd characters to
+    # their hex representation rather than just using "\\".
+    if re.escape(char) != char:
+        return '\\x%0.2X' % ord(char)
+    else:
+        return char
 
 
 # The collection of "escapable" characters differs between Python 2 and
@@ -10,11 +21,11 @@ from parsimonious import Grammar
 # See revex.tests.test_parser.test_escapable_chars, where it is verified that
 # the list is correct.
 if sys.version_info < (3, ):
-    ESCAPABLE_CHARS = 'ceghijklmopquyzCEFGHIJKLMNOPQRTUVXY\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
-    CHARSET_ESCAPABLE_CHARS = 'ceghijklmopquyzABCEFGHIJKLMNOPQRTUVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
+    ESCAPABLE_CHARS = u'ceghijklmopquyzCEFGHIJKLMNOPQRTUVXY!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r\x0b\x0c'  # noqa
+    CHARSET_ESCAPABLE_CHARS = 'ceghijklmopquyzABCEFGHIJKLMNOPQRTUVXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r\x0b\x0c'  # noqa
 else:
-    ESCAPABLE_CHARS = 'ceghijklmopqyzCEFGHIJKLMNOPQRTVXY\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
-    CHARSET_ESCAPABLE_CHARS = 'ceghijklmopqyzABCEFGHIJKLMNOPQRTVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
+    ESCAPABLE_CHARS = 'ceghijklmopqyzCEFGHIJKLMNOPQRTVXY!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r\x0b\x0c'  # noqa
+    CHARSET_ESCAPABLE_CHARS = 'ceghijklmopqyzABCEFGHIJKLMNOPQRTVXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r\x0b\x0c'  # noqa
 
 
 REGEX = Grammar(r'''
@@ -54,6 +65,6 @@ REGEX = Grammar(r'''
     character_set = "[" "^"? set_items "]"
     set_char = escaped_numeric_character / escaped_set_char / ~"[^\\]]"
     escaped_set_char = "\\" ~"[%s]"
-    set_items = (range / escaped_set_char / escaped_character / ~"[^\\]]" )+
+    set_items = (range / escaped_numeric_character / escaped_whitespace / escaped_set_char / ~"[^\\]]" )+
     range = set_char  "-" set_char
-''' % CHARSET_ESCAPABLE_CHARS)  # noqa
+''' % ''.join(map(double_regex_escape, CHARSET_ESCAPABLE_CHARS)))  # noqa

--- a/revex/regex_grammar.py
+++ b/revex/regex_grammar.py
@@ -10,11 +10,11 @@ from parsimonious import Grammar
 # See revex.tests.test_parser.test_escapable_chars, where it is verified that
 # the list is correct.
 if sys.version_info < (3, ):
-    ESCAPABLE_CHARS = '0abcdefghijklmnopqrstuvwyzCEFGHIJKLMNOPQRTUVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^\\_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
-    CHARSET_ESCAPABLE_CHARS = '0abcdefghijklmnopqrstuvwyzCEFGHIJKLMNOPQRTUVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^\\_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
+    ESCAPABLE_CHARS = 'ceghijklmopquyzCEFGHIJKLMNOPQRTUVXY\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
+    CHARSET_ESCAPABLE_CHARS = 'ceghijklmopquyzABCEFGHIJKLMNOPQRTUVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
 else:
-    ESCAPABLE_CHARS = '0abcdefghijklmnopqrstvwyzCEFGHIJKLMNOPQRTVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
-    CHARSET_ESCAPABLE_CHARS = '0abcdefghijklmnopqrstvwyzCEFGHIJKLMNOPQRTVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
+    ESCAPABLE_CHARS = 'ceghijklmopqyzCEFGHIJKLMNOPQRTVXY\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
+    CHARSET_ESCAPABLE_CHARS = 'ceghijklmopqyzABCEFGHIJKLMNOPQRTVXYZ\\!\\"\\#\\$\\%\\&\\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^_\\`\\{\\|\\}\\~\\ \\\t\\\n\\\r\\\x0b\\\x0c'  # noqa
 
 
 REGEX = Grammar(r'''

--- a/revex/regex_grammar.py
+++ b/revex/regex_grammar.py
@@ -49,10 +49,10 @@ REGEX = Grammar(r'''
     comment = "(?#" ("\)" / ~"[^)]")* ")"
 
     escaped_character =
+        escaped_whitespace /
         escaped_metachar /
-        escaped_numeric_character /
-        escaped_whitespace
-    escaped_metachar = "\\" ~"[.$^\\\\*+()|{}?\\][/]"
+        escaped_numeric_character
+    escaped_metachar = "\\" ~"[%s]"
     escaped_numeric_character =
         ("\\"  ~"[0-7]{3}") /
         ("\\x" ~"[0-9a-f]{2}"i) /
@@ -67,4 +67,8 @@ REGEX = Grammar(r'''
     escaped_set_char = "\\" ~"[%s]"
     set_items = (range / escaped_numeric_character / escaped_whitespace / escaped_set_char / ~"[^\\]]" )+
     range = set_char  "-" set_char
-''' % ''.join(map(double_regex_escape, CHARSET_ESCAPABLE_CHARS)))  # noqa
+''' % (  # noqa
+        ''.join(map(double_regex_escape, ESCAPABLE_CHARS)),
+        ''.join(map(double_regex_escape, CHARSET_ESCAPABLE_CHARS)),
+    )
+)

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -330,15 +330,17 @@ def test_escapable_chars():
 
     def is_char_escapable(char):
         try:
-            return not re.compile(r'\{char}'.format(char=char)).match('\\%s' % char)
-        except Exception as e:
+            regex = re.compile(r'^\{char}$'.format(char=char))
+        except Exception:
             return False
+        return {c for c in string.printable if regex.match(c)} == {char}
 
     def is_char_escapable_in_charsets(char):
         try:
-            return not re.compile(r'[\{char}]'.format(char=char)).match('\\')
-        except Exception as e:
+            regex = re.compile(r'^[\{char}]$'.format(char=char))
+        except Exception:
             return False
+        return {c for c in string.printable if regex.match(c)} == {char}
 
     assert ESCAPABLE_CHARS == re.escape(''.join(filter(is_char_escapable, string.printable)))
     assert CHARSET_ESCAPABLE_CHARS == re.escape(''.join(filter(is_char_escapable_in_charsets, string.printable)))

--- a/revex/tests/test_parser.py
+++ b/revex/tests/test_parser.py
@@ -342,5 +342,6 @@ def test_escapable_chars():
             return False
         return {c for c in string.printable if regex.match(c)} == {char}
 
-    assert ESCAPABLE_CHARS == re.escape(''.join(filter(is_char_escapable, string.printable)))
-    assert CHARSET_ESCAPABLE_CHARS == re.escape(''.join(filter(is_char_escapable_in_charsets, string.printable)))
+    assert ESCAPABLE_CHARS == ''.join(filter(is_char_escapable, string.printable))
+    assert CHARSET_ESCAPABLE_CHARS == ''.join(filter(is_char_escapable_in_charsets,
+                                                     string.printable))


### PR DESCRIPTION
Fixes #22. This PR expands the tests for character escaping, and harmonizes the escaping behavior between python's regex parser and revex's grammar.